### PR TITLE
Make logo non-fuzzy

### DIFF
--- a/css/general.less
+++ b/css/general.less
@@ -7,7 +7,7 @@
 @screen-medium-res: 1000px;
 @screen-high-res:   1200px;
 
-@logo-width: 200px;
+@logo-width: 199px;
 
 @dark-grey: #999;
 


### PR DESCRIPTION
The logo file is 199px wide, so setting this to 200px makes it a bit fuzzy.
